### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "nodemailer": "^7.0.11",
     "path": "^0.12.7",
     "uuid": "^13.0.0",
-    "winston": "^3.18.3"
+    "winston": "^3.18.3",
+    "striptags": "^3.2.0"
   }
 }

--- a/utils/emailService.js
+++ b/utils/emailService.js
@@ -1,6 +1,7 @@
 const nodemailer = require('nodemailer');
 const fs = require('fs-extra');
 const path = require('path');
+const striptags = require('striptags');
 
 class EmailService {
     constructor() {
@@ -419,7 +420,7 @@ class EmailService {
 
     // Utility function to strip HTML tags for plain text version
     stripHtml(html) {
-        return html.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+        return striptags(html).replace(/\s+/g, ' ').trim();
     }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/kavineksith/IMIPS-REST-API/security/code-scanning/11](https://github.com/kavineksith/IMIPS-REST-API/security/code-scanning/11)

To robustly fix this issue, we should either use a trusted open-source library that reliably strips HTML tags and content, or make the regular expression replacement iterative so that repeated overlapping/malformed tags are completely removed. The best-known library for this in JavaScript/Node.js is `striptags`. To implement this:
- Add `striptags` as a dependency (`npm install striptags`).
- Replace the current regex-based `stripHtml` method with a call to the `striptags` library.

This change only needs to be made in `utils/emailService.js`, at the definition of `stripHtml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
