### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled data used in path expression

### DIFF
--- a/middleware/security.js
+++ b/middleware/security.js
@@ -189,7 +189,7 @@ const fileUploadSecurity = async (req, res, next) => {
         // Validate that the file path is under the UPLOAD_ROOT directory
         const uploadFilePath = path.resolve(UPLOAD_ROOT, path.basename(req.file.path));
         if (!uploadFilePath.startsWith(UPLOAD_ROOT)) {
-            await require('fs-extra').unlink(req.file.path);
+            await require('fs-extra').unlink(uploadFilePath);
             return res.status(400).json({
                 message: 'Invalid upload location detected.'
             });


### PR DESCRIPTION
Potential fix for [https://github.com/kavineksith/IMIPS-REST-API/security/code-scanning/14](https://github.com/kavineksith/IMIPS-REST-API/security/code-scanning/14)

To fix this issue, we should ensure that any file operations, including deletion, are only performed on paths that have been properly normalized and validated to reside within the intended `UPLOAD_ROOT` directory. Instead of using the possibly untrusted `req.file.path` directly, we should always use the already-sanitized `uploadFilePath` (as built on line 190 and validated on line 191).

- Change the call to `require('fs-extra').unlink(req.file.path);` on line 192 to instead use `uploadFilePath` (the safe, normalized absolute path).
- In the catch block (lines 235–239), where the code again attempts to unlink the uploaded file (`await require('fs-extra').unlink(uploadFilePath);`), make sure to use the same, sanitized path.
- No extra imports are required, as all necessary modules are already imported elsewhere in the file.
- No further methods/definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
