### PR TITLE
Potential fix for code scanning alert no. 9: Uncontrolled data used in path expression

### DIFF
--- a/routes/emails.js
+++ b/routes/emails.js
@@ -174,7 +174,13 @@ router.post('/send', authenticateToken, requireRole(['Admin', 'Manager']), uploa
             // Delete the attachment since email failed
             if (attachmentPath) {
                 try {
-                    await fs.unlink(path.join(__dirname, '..', attachmentPath));
+                    // Ensure the path to unlink is strictly within the ATTACHMENTS_DIR
+                    const attachmentAbsolutePath = path.resolve(ATTACHMENTS_DIR, path.basename(attachmentPath));
+                    if (attachmentAbsolutePath.startsWith(ATTACHMENTS_DIR)) {
+                        await fs.unlink(attachmentAbsolutePath);
+                    } else {
+                        console.warn('Attempted to delete a file outside attachments directory:', attachmentAbsolutePath);
+                    }
                 } catch (unlinkError) {
                     console.warn('Could not delete attachment:', unlinkError);
                 }


### PR DESCRIPTION
Potential fix for [https://github.com/kavineksith/IMIPS-REST-API/security/code-scanning/9](https://github.com/kavineksith/IMIPS-REST-API/security/code-scanning/9)

To address the risk of uncontrolled user input in path expressions, and in line with best security practices, we must ensure that the path given to `fs.unlink` when deleting the file (and similarly for email attachment sending) **never escapes the intended attachment directory**.

Recommended approach:  
- Normalize and resolve the file path so that all symlinks and dot-dot paths are eliminated and the path is absolute.
- Check that the resolved path starts with the intended safe root directory (here, the `/uploads/attachments/` directory inside the project).
- Only if this check passes, proceed to delete the file; otherwise, skip deletion or log a warning.

To do this, we will:
- Define a `const ATTACHMENTS_DIR` at the top (e.g., `path.join(__dirname, '../uploads/attachments')`)
- When joining `attachmentPath`, convert it into an absolute path under `ATTACHMENTS_DIR`.
- Use `path.resolve` to normalize the full path, and ensure the path starts with `ATTACHMENTS_DIR`
- Only `fs.unlink` if the check passes.

No new dependencies are needed; only Node's built-in modules are used.

**Areas to change:**  
- Add `const ATTACHMENTS_DIR = ...` near the top.
- In the error handling block (`fs.unlink`), resolve and validate the full path before calling delete.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
