### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -312,7 +312,7 @@ const initializeDatabase = async () => {
       console.log('\n' + '='.repeat(60));
       console.log('IMPORTANT: Default admin account created!');
       console.log('Email: admin@imips.com');
-      console.log('Password:', defaultPassword);
+      console.log('Password: <hidden> (written to ADMIN_CREDENTIALS.txt)');
       console.log('CHANGE THIS PASSWORD IMMEDIATELY AFTER FIRST LOGIN!');
       console.log('='.repeat(60) + '\n');
 


### PR DESCRIPTION
Potential fix for [https://github.com/kavineksith/IMIPS-REST-API/security/code-scanning/1](https://github.com/kavineksith/IMIPS-REST-API/security/code-scanning/1)

To fix the issue, we must ensure that the generated `defaultPassword` is *not* written to the console as clear text. The fix is to remove or redact the line `console.log('Password:', defaultPassword);`, replacing it with an instruction on how to retrieve the password securely, or simply not logging it at all. Optionally, if `NODE_ENV !== 'production'`, a warning could be provided about where the credentials are stored (e.g., in `./ADMIN_CREDENTIALS.txt` for production environments), but the password itself should never be logged to the console. Code that writes credentials to a file (`./ADMIN_CREDENTIALS.txt`) with restrictive permissions is permissible as long as console output doesn't expose the password.

Specifically:
- Remove or replace line 315 (`console.log('Password:', defaultPassword);`) such that the password is not outputted to the console.
- Optionally, provide a message stating, "Admin credentials written to ADMIN_CREDENTIALS.txt," if in production.
- No additional imports or third-party libraries are needed; the rest of the implementation can remain untouched.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
