### PR TITLE
Potential fix for code scanning alert no. 16: Clear-text logging of sensitive information

### DIFF
--- a/scripts/generate-keys.js
+++ b/scripts/generate-keys.js
@@ -55,20 +55,9 @@ console.log('All secrets have been generated and written to: ' + outputFile);
 console.log('Open this file, copy values as needed to your .env file, then securely DELETE the file.');
 console.log('If you need secrets printed to stdout, rerun this script with: node scripts/generate-keys.js --stdout');
 
-// Optional: Show secrets to stdout if explicitly requested by a flag
+// Refuse to show secrets on stdout, even if explicitly requested
 if (process.argv.includes('--stdout')) {
-    console.log('\n='.repeat(70));
-    console.log('IMIPS Security Key Generator (SHOWING SECRETS ON STDOUT -- INSECURE)');
-    console.log('='.repeat(70));
-    console.log('\nJWT_SECRET:');
-    console.log(jwtSecret);
-    console.log('\nENCRYPTION_KEY:');
-    console.log(encryptionKey);
-    console.log('\nDB_PASSWORD:');
-    console.log(dbPassword);
-    console.log('\nADMIN_PASSWORD:');
-    console.log(adminPassword);
-    console.log('\n');
+    console.log('Refusing to print sensitive secrets to stdout. Please see the generated-keys.txt file for your generated secrets and handle it securely.');
 }
 console.log('='.repeat(70));
 console.log('IMPORTANT SECURITY NOTES:');


### PR DESCRIPTION
Potential fix for [https://github.com/kavineksith/IMIPS-REST-API/security/code-scanning/16](https://github.com/kavineksith/IMIPS-REST-API/security/code-scanning/16)

The best fix is to never allow secrets such as database passwords (or any secret values) to be printed to stdout, even under special flags, and instead make the user access the generated file for the values. This ensures secrets are only written to the secure file and not exposed in logs or console output.  
To implement this, remove or comment out the conditional block (lines 59–72) that prints secrets to stdout. Instead, if `--stdout` is supplied, print a warning message only (e.g., "Refusing to print sensitive secrets to stdout. Please see the generated-keys.txt file.").  

Edits needed:  
- In `scripts/generate-keys.js`, delete or replace the block starting at line 59 (`if (process.argv.includes('--stdout')) { ... }`) with a message explaining that secrets will not be printed to stdout and must be retrieved from the generated file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
